### PR TITLE
Add path from DSN to the API http client

### DIFF
--- a/src/WeblateProviderFactory.php
+++ b/src/WeblateProviderFactory.php
@@ -73,8 +73,12 @@ class WeblateProviderFactory extends AbstractProviderFactory
 
         $endpoint = $dsn->getHost();
         $endpoint .= $dsn->getPort() ? ':'.$dsn->getPort() : '';
+        $path = trim($dsn->getPath(), '/');
+        if (strlen($path) > 0) {
+            $path = '/'.$path;
+        }
         $api = $this->bundleConfig['https'] ? 'https://' : 'http://';
-        $api .= $endpoint.'/api/';
+        $api .= $endpoint.$path.'/api/';
 
         $client = ScopingHttpClient::forBaseUri(
             $this->client,


### PR DESCRIPTION
Hello, 
First of all thank you for your work!
I open the PR because in our setup at Pilcrow we have multiple instances in subdirectories and so the DSN must include the path to work.
I think it's a legit change to have anyway.
Let me know

